### PR TITLE
Add include_paths config option for libsass

### DIFF
--- a/configs/scss.ini
+++ b/configs/scss.ini
@@ -4,3 +4,4 @@ output_style = compressed
 source_comments = False
 precision = 5
 name_prefix = .min
+: include_paths = node_modules/,assets/vendor/

--- a/configs/scss.ini
+++ b/configs/scss.ini
@@ -4,4 +4,4 @@ output_style = compressed
 source_comments = False
 precision = 5
 name_prefix = .min
-: include_paths = node_modules/,assets/vendor/
+; include_paths = node_modules/,assets/vendor/

--- a/lektor_scss.py
+++ b/lektor_scss.py
@@ -20,7 +20,6 @@ class scssPlugin(Plugin):
     def __init__(self, *args, **kwargs):
         Plugin.__init__(self, *args, **kwargs)
         config = self.get_config()
-        
         self.source_dir = config.get('source_dir', 'assets/scss/')
         self.output_dir = config.get('output_dir', 'assets/css/')
         self.output_style = config.get('output_style', 'compressed')
@@ -93,7 +92,6 @@ class scssPlugin(Plugin):
                 break
         if not rebuild:
             return
-        print("include %s" % self.include_paths)
         result = sass.compile(
                 filename=target,
                 output_style=self.output_style,


### PR DESCRIPTION
If you want to include SASS libraries from a different directory, libsass's compile function has a parameter called include_paths to add those directories to the search path. 

This is very handy if you (for example) want to install third-party SASS modules via NPM or yarn (e.g. install bootstrap via `npm install bootstrap`) or if you want to keep third-party modules in a completely separate directory from your SASS/SCSS code.